### PR TITLE
Bugfix http(s) timeout handling

### DIFF
--- a/nctalkaccess.js
+++ b/nctalkaccess.js
@@ -9,7 +9,7 @@ class TalkAccess {
             host: _options.server,
             port: _options.port,
             path: "",
-            timeout: 40000,
+            timeout: 120000,  // Make the http connection timeout larger than the nextcloud talk wait new msg timeout (30 by default, 60 at most)
             method: "",
             // authentication headers
             headers: {
@@ -53,7 +53,9 @@ class TalkAccess {
             Callback("ERROR", e);
         }).bind(this));
         req.on('timeout', (function () {
-            Callback("TIMEOUT");
+            // http timeout - IMPORTANT: socket is still open and can trigger one of the callback aboves!
+            // call abort request --> leading to socket hang up error --> No Callback to calling layer here
+            req.abort();
         }).bind(this));
 
         if (body) {

--- a/nctalkcapabilities.js
+++ b/nctalkcapabilities.js
@@ -39,9 +39,6 @@ class TalkCapabilities {
                 case "ERROR":
                     Callback("ERROR", res);
                     break;
-                case "TIMEOUT":
-                    Callback("TIMEOUT");
-                    break;
             }
 
         });

--- a/nctalkclient.js
+++ b/nctalkclient.js
@@ -104,10 +104,12 @@ class Talkclient extends EventEmitter {
     }
 
     ErrorLog(msg) {
+        //global.ErrorLog(msg);
         this.emit("Error", msg);
     }
 
     DebugLog(msg) {
+        //global.DebugLog(msg);
         if (this.debug == true) {
             this.emit("Debug", msg);
         }
@@ -246,7 +248,7 @@ class Talkclient extends EventEmitter {
                         }
                         else if (retcode == "NOMSG") {
                             this.DebugLog(res);
-                            this._EventloopTrigger("WaitNewMessages done");
+                            this._EventloopTrigger("WaitNewMessages done", 1000);
                         } else {
                             // Don't get in ERROR state report it and retry until connection is back or aborted
                             // Typically two types of error - server is not reachable

--- a/nctalkclient.js
+++ b/nctalkclient.js
@@ -144,7 +144,7 @@ class Talkclient extends EventEmitter {
     // we will see how to best handle this here
         const listofrooms = this.rooms.getlistofrooms();
         for (const key in listofrooms) {
-            this.conversation[key] = new TalkConversation(this.nchttp, this.capabilities, listofrooms[key]);
+            this.conversation[key] = new TalkConversation(this, this.nchttp, this.capabilities, listofrooms[key]);
         }
     }
 

--- a/nctalkconversation.js
+++ b/nctalkconversation.js
@@ -69,8 +69,11 @@ class TalkConversation {
             this.nchttp.RequestfromHost("GET", this._geturl("WaitNewMessages"), null, (retcode, res) => {
 
                 // WaitNewMessages is done - do this before any callbacks are called in case the trigger a new WaitNewMessage
+                if(this.waitmsgongoing == false)
+                    console.log("Callback called with waitmsgongoing = false!");
+
+                this.talkclient.DebugLog("WaitNewMessages OUT " + this.roominfo.token + " " + this.waitmsgongoing);
                 this.waitmsgongoing = false;
-                this.talkclient.DebugLog("WaitNewMessages OUT " + this.roominfo.token);
 
                 switch (retcode) {
                     case "OK":

--- a/nctalkconversation.js
+++ b/nctalkconversation.js
@@ -4,10 +4,12 @@
 
 class TalkConversation {
 
-    constructor(nchttp, capabilities, roominfo) {
+    constructor(talkclient, nchttp, capabilities, roominfo) {
         this.nchttp = nchttp;
         this.capabilities = capabilities;
         this.roominfo = roominfo;
+
+        this.talkclient = talkclient;
 
         this.lastmsgid = roominfo.lastReadMessage;
         this.listenactive = false;    // We start with active listing off
@@ -63,10 +65,12 @@ class TalkConversation {
     WaitNewMessages(Callback) {
         if ((this.listenactive == true) && (this.waitmsgongoing == false)) {
             this.waitmsgongoing = true;  // Only one WaitNewMessages per conversation
+            this.talkclient.DebugLog("WaitNewMessages IN " + this.roominfo.token);
             this.nchttp.RequestfromHost("GET", this._geturl("WaitNewMessages"), null, (retcode, res) => {
 
                 // WaitNewMessages is done - do this before any callbacks are called in case the trigger a new WaitNewMessage
                 this.waitmsgongoing = false;
+                this.talkclient.DebugLog("WaitNewMessages OUT " + this.roominfo.token);
 
                 switch (retcode) {
                     case "OK":

--- a/nctalkconversation.js
+++ b/nctalkconversation.js
@@ -51,8 +51,6 @@ class TalkConversation {
                     break;
                 case "ERROR":
                     break;
-                case "TIMEOUT":
-                    break;
             }
         });
 
@@ -68,10 +66,18 @@ class TalkConversation {
             this.talkclient.DebugLog("WaitNewMessages IN " + this.roominfo.token);
             this.nchttp.RequestfromHost("GET", this._geturl("WaitNewMessages"), null, (retcode, res) => {
 
+                //console.log("DUMP",this.talkclient,this.nchttp);
+                // console.log("totalSocketCount",this.nchttp._http.globalAgent.totalSocketCount);
+                // console.log("Wait Counter ",this.waitcnt,this.roominfo.token,retcode,res);
+
                 // WaitNewMessages is done - do this before any callbacks are called in case the trigger a new WaitNewMessage
                 if(this.waitmsgongoing == false)
-                    console.log("Callback called with waitmsgongoing = false!");
+                {
+                    this.talkclient.DebugLog("Callback called with waitmsgongoing = false!", this.roominfo.token, retcode, res);
+                }
 
+                //console.log(this.roominfo.token, this.nchttp._http.globalAgent.sockets);
+                //console.log(this.roominfo.token, this.nchttp);
                 this.talkclient.DebugLog("WaitNewMessages OUT " + this.roominfo.token + " " + this.waitmsgongoing);
                 this.waitmsgongoing = false;
 
@@ -100,11 +106,6 @@ class TalkConversation {
                         break;
                     case "ERROR":
                         Callback("ERROR", res);
-                        break;
-                    case "TIMEOUT":
-                        // This is a http connection timeout which indicates server went offline or is no more reachable while waiting
-                        // Make the http connection timeout larger than the nextcloud talk wait new msg timeout (30 by default, 60 at most)
-                        Callback("TIMEOUT");
                         break;
                 }
             });

--- a/nctalkrooms.js
+++ b/nctalkrooms.js
@@ -41,10 +41,6 @@ class TalkRooms {
                     //console.log("TalkRooms get ERROR", res);
                     Callback("ERROR", res);
                     break;
-                case "TIMEOUT":
-                    //console.log("TalkRooms get TIMEOUT");
-                    Callback("TIMEOUT");
-                    break;
             }
         });
     }


### PR DESCRIPTION
http(s) request timeout handling changed. As it looks like the http timeout still keeps socket open and triggers spurious callbacks which is suspected to causes a http request storm of waitmessage requests. Beside this 1sec delay for next trigger was added.
